### PR TITLE
Fix issue where defunt processes accumulate

### DIFF
--- a/beater/collect.go
+++ b/beater/collect.go
@@ -79,6 +79,10 @@ func (pb *Packagebeat) collectPackages(manager string, cmd string, args ...strin
 			"summary":      pkg.summary,
 		})
 	}
+        if err := x.Wait(); err != nil {
+                logp.Err("%v", err)
+                return err
+        }
 	return nil
 }
 


### PR DESCRIPTION
Add a wait for the pipe to complete before exiting the collect loop.  resolves #1
